### PR TITLE
296 Characters (preserves UI, margins, sizing and placeholder text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 Paste the following code into your browser address bar:
 
-	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style><script>y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')</script>
+	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style><script>document.write('HTML,CSS,JS,<iframe id=i>'.replace(/((.).+?),/g,'<textarea placeholder=$1 id=$2 t></textarea>'))</script>
+
 
 If you want to read the code, check out [index.html](https://github.com/umpox/TinyEditor/blob/master/index.html)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 Paste the following code into your browser address bar:
 
-	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style><script>var y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')</script>
+	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style><script>y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')</script>
 
 If you want to read the code, check out [index.html](https://github.com/umpox/TinyEditor/blob/master/index.html)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 Paste the following code into your browser address bar:
 
-	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0;font-size:18}.t{width:33.33%}.t,#i{height:50%}</style><script>var y=x=>`<textarea class=t id=${x[0]} placeholder=${x}></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>');</script>
+	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0;font-size:18}[t]{width:33.33%}[id]{height:50%}</style><script>var y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')</script>
 
 If you want to read the code, check out [index.html](https://github.com/umpox/TinyEditor/blob/master/index.html)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 Paste the following code into your browser address bar:
 
-	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0;font-size:18}[t]{width:33.33%}[id]{height:50%}</style><script>var y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')</script>
+	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style><script>var y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')</script>
 
 If you want to read the code, check out [index.html](https://github.com/umpox/TinyEditor/blob/master/index.html)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 Paste the following code into your browser address bar:
 
-    data:text/html,<body oninput="i.srcdoc=h.value+'<style>'+c.value+'</style><script>'+j.value+'</script>'"><style>textarea,iframe{width:100%;height:50%}body{margin:0}textarea{width:33.33%;font-size:18}</style><textarea placeholder=HTML id=h></textarea><textarea placeholder=CSS id=c></textarea><textarea placeholder=JS id=j></textarea><iframe id=i>
+	data:text/html,<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`"><style>*{width:100%;margin:0;font-size:18}.t{width:33.33%}.t,#i{height:50%}</style><script>var y=x=>`<textarea class=t id=${x[0]} placeholder=${x}></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>');</script>
 
 If you want to read the code, check out [index.html](https://github.com/umpox/TinyEditor/blob/master/index.html)

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`">
+	<style>*{width:100%;margin:0;font-size:18}[t]{width:33.33%}[id]{height:50%}</style>
 	<script>
-		var y=x=>`<textarea class=t id=${x[0]} placeholder=${x}></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>');
+		var y=x=>`<textarea id=${x[0]} placeholder=${x} t/>`;
+		document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')
 	</script>
-	<style>
-		*{width:100%;margin:0;font-size:18}.t{width:33.33%}.t,#i{height:50%}
+			

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`">
 	<style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style>
-	<script>
-		var y=x=>`<textarea id=${x[0]} placeholder=${x} t/>`;
-		document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')
+	<script>y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;
+			document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')
 	</script>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 <body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`">
-	<style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style>
-	<script>y=x=>`<textarea id=${x[0]} placeholder=${x} t></textarea>`;
-			document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')
+	<style>
+		*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}
+	</style>
+	<script>
+		document.write('HTML,CSS,JS,<iframe id=i>'.replace(/((.).+?),/g,'<textarea placeholder=$1 id=$2 t></textarea>'))
 	</script>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`">
-	<style>*{width:100%;margin:0;font-size:18}[t]{width:33.33%}[id]{height:50%}</style>
+	<style>*{width:100%;margin:0}[t]{width:33.33%}[id]{height:50%}</style>
 	<script>
 		var y=x=>`<textarea id=${x[0]} placeholder=${x} t/>`;
 		document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>')
 	</script>
-			

--- a/index.html
+++ b/index.html
@@ -1,12 +1,6 @@
-<body 
-    oninput="i.srcdoc=h.value+'<style>'+c.value+
-            '</style><script>'+j.value+'<\/script>'">
-    <style>
-        textarea,iframe{width:100%;height:50%}
-        body{margin:0}
-        textarea{width:33.33%;font-size:18}
-    </style>
-    <textarea placeholder=HTML id=h></textarea>
-    <textarea placeholder=CSS id=c></textarea>
-    <textarea placeholder=JS id=j></textarea>
-    <iframe id=i>
+<body oninput="i.srcdoc=`${H.value}<script>${J.value}</script><style>${C.value}`">
+	<script>
+		var y=x=>`<textarea class=t id=${x[0]} placeholder=${x}></textarea>`;document.write(y('HTML')+y('CSS')+y('JS')+'<iframe id=i>');
+	</script>
+	<style>
+		*{width:100%;margin:0;font-size:18}.t{width:33.33%}.t,#i{height:50%}


### PR DESCRIPTION
296 characters:

Demo: https://github.com/umpox/TinyEditor/blob/b0694b20467aea032b4d99fb84ef855f014f48d5/README.md

I'm not a fan of removing placeholder text, the goal is to still be clear to the end user what each input box does, therefore the code has mostly be minimised while mostly preserving UI.
 
 - Using regex to generate repetitive HTML
 - Use of template literals
 - Using custom single character HTML selectors
 - Use of [id] selector and * wildcard selector
 - Use of document.write()
 - Generate single character ID from as first character from placeholder text

UI Changes:
 - font-size: 18 removed, however everything else remains.